### PR TITLE
use go:embed and 1.16 to support wasm

### DIFF
--- a/examples/logo/main.go
+++ b/examples/logo/main.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	_ "embed"
 	_ "image/png"
 
 	"github.com/kvartborg/vector"
@@ -35,8 +36,10 @@ type Game struct {
 	PrevMousePosition vector.Vector
 }
 
-func NewGame() *Game {
+//go:embed tetra3d.dae
+var logoModel []byte
 
+func NewGame() *Game {
 	game := &Game{
 		Width:             398,
 		Height:            224,
@@ -50,8 +53,10 @@ func NewGame() *Game {
 }
 
 func (g *Game) Init() {
-
-	dae, _ := tetra3d.LoadDAEFile("tetra3d.dae", nil)
+	dae, err := tetra3d.LoadDAEData(logoModel, nil)
+	if err != nil {
+		panic(err)
+	}
 
 	g.Scene = dae
 
@@ -63,11 +68,9 @@ func (g *Game) Init() {
 	g.Camera.Position[2] = 5
 
 	ebiten.SetCursorMode(ebiten.CursorModeCaptured)
-
 }
 
 func (g *Game) Update() error {
-
 	var err error
 
 	moveSpd := 0.05
@@ -169,11 +172,9 @@ func (g *Game) Update() error {
 	}
 
 	return err
-
 }
 
 func (g *Game) Draw(screen *ebiten.Image) {
-
 	// Clear, but with a color
 	screen.Fill(color.RGBA{60, 70, 80, 255})
 
@@ -204,13 +205,10 @@ func (g *Game) Draw(screen *ebiten.Image) {
 	if g.DrawDebugText {
 		g.Camera.DrawDebugText(screen, 1)
 	}
-
 }
 
 func (g *Game) StartProfiling() {
-
 	outFile, err := os.Create("./cpu.pprof")
-
 	if err != nil {
 		fmt.Println(err.Error())
 		return
@@ -223,7 +221,6 @@ func (g *Game) StartProfiling() {
 		pprof.StopCPUProfile()
 		fmt.Println("CPU profiling finished.")
 	}()
-
 }
 
 func (g *Game) Layout(w, h int) (int, int) {
@@ -231,7 +228,6 @@ func (g *Game) Layout(w, h int) (int, int) {
 }
 
 func main() {
-
 	ebiten.SetWindowTitle("Tetra3d Test - Logo")
 	ebiten.SetWindowResizable(true)
 
@@ -240,5 +236,4 @@ func main() {
 	if err := ebiten.RunGame(game); err != nil {
 		panic(err)
 	}
-
 }

--- a/examples/shapes/main.go
+++ b/examples/shapes/main.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	_ "embed"
 	_ "image/png"
 
 	"github.com/golang/freetype/truetype"
@@ -23,6 +24,12 @@ import (
 	"github.com/hajimehoshi/ebiten/v2/inpututil"
 	"github.com/hajimehoshi/ebiten/v2/text"
 )
+
+//go:embed excel.ttf
+var fontData []byte
+
+//go:embed shapes.dae
+var shapesDAE []byte
 
 type Game struct {
 	Width, Height int
@@ -41,17 +48,11 @@ type Game struct {
 }
 
 func NewGame() *Game {
-
 	game := &Game{
 		Width:             398,
 		Height:            224,
 		PrevMousePosition: vector.Vector{},
 		DrawDebugText:     true,
-	}
-
-	fontData, err := os.ReadFile("excel.ttf")
-	if err != nil {
-		panic(err)
 	}
 
 	tt, err := truetype.Parse(fontData)
@@ -67,12 +68,10 @@ func NewGame() *Game {
 }
 
 func (g *Game) Init() {
-
 	// Load the DAE file and turn it into a scene. Note that we could also pass options to change how the file
 	// is loaded (specifically, which way is up), but we don't have to do that because it will do this by default if
 	// nil is passed as the second argument.
-	dae, err := tetra3d.LoadDAEFile("shapes.dae", nil)
-
+	dae, err := tetra3d.LoadDAEData(shapesDAE, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -110,11 +109,9 @@ func (g *Game) Init() {
 	// but this will turn off inter-object depth sorting. Instead, Tetra's Camera will render objects in order of distance to camera.
 
 	ebiten.SetCursorMode(ebiten.CursorModeCaptured)
-
 }
 
 func (g *Game) Update() error {
-
 	var err error
 
 	moveSpd := 0.1
@@ -222,11 +219,9 @@ func (g *Game) Update() error {
 	}
 
 	return err
-
 }
 
 func (g *Game) Draw(screen *ebiten.Image) {
-
 	// Clear, but with a color
 	// screen.Fill(color.RGBA{20, 25, 30, 255})
 	screen.Fill(color.Black)
@@ -251,13 +246,10 @@ func (g *Game) Draw(screen *ebiten.Image) {
 		txt := "F1 to toggle this text\nWASD: Move, Mouse: Look\n1, 2, 3, 4: Change fog\nF1, F2, F3, F5: Debug views\nF4: Toggle fullscreen\nESC: Quit"
 		text.Draw(screen, txt, g.Font, 248, 128, color.RGBA{255, 0, 0, 255})
 	}
-
 }
 
 func (g *Game) StartProfiling() {
-
 	outFile, err := os.Create("./cpu.pprof")
-
 	if err != nil {
 		fmt.Println(err.Error())
 		return
@@ -270,7 +262,6 @@ func (g *Game) StartProfiling() {
 		pprof.StopCPUProfile()
 		fmt.Println("CPU profiling finished.")
 	}()
-
 }
 
 func (g *Game) Layout(w, h int) (int, int) {
@@ -278,7 +269,6 @@ func (g *Game) Layout(w, h int) (int, int) {
 }
 
 func main() {
-
 	ebiten.SetWindowTitle("Tetra3d Test - Shapes")
 	ebiten.SetWindowResizable(true)
 
@@ -287,5 +277,4 @@ func main() {
 	if err := ebiten.RunGame(game); err != nil {
 		panic(err)
 	}
-
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/solarlune/tetra3d
 
-go 1.14
+go 1.16
 
 require (
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0


### PR DESCRIPTION
Opening another PR since I messed up the first one (#2).

> Just adds `//go:embed` and bumps Go version to 1.16, since that's required for `//go:embed` and the README already claims to support 1.16+.