### PR TITLE
Increase glTF parsing performance

### DIFF
--- a/fastmath.go
+++ b/fastmath.go
@@ -79,10 +79,10 @@ type VectorPool struct {
 
 func NewVectorPool(vectorCount int) *VectorPool {
 	pool := &VectorPool{
-		Vectors: []vector.Vector{},
+		Vectors: make([]vector.Vector, vectorCount),
 	}
 	for i := 0; i < vectorCount; i++ {
-		pool.Vectors = append(pool.Vectors, vector.Vector{0, 0, 0, 0})
+		pool.Vectors[i] = vector.Vector{0, 0, 0, 0}
 	}
 	return pool
 }

--- a/gltf_test.go
+++ b/gltf_test.go
@@ -1,0 +1,23 @@
+package tetra3d
+
+import (
+	"os"
+	"testing"
+)
+
+func BenchmarkLoadGLTFData(b *testing.B) {
+	b.StopTimer()
+	data, err := os.ReadFile("./examples/logo/tetra3d.glb")
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.StartTimer()
+	b.ReportAllocs()
+	b.SetBytes(int64(len(data)))
+	for i := 0; i < b.N; i++ {
+		_, err = LoadGLTFData(data, nil)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/mesh.go
+++ b/mesh.go
@@ -463,12 +463,13 @@ func (part *MeshPart) Clone() *MeshPart {
 		Triangles:       make([]*Triangle, len(part.Triangles)),
 		sortedTriangles: make([]*Triangle, len(part.Triangles)),
 		Material:        part.Material,
+		Vertices:        make([]*Vertex, 0, len(part.Triangles)*3),
 	}
 	for i, tri := range part.Triangles {
 		newTri := tri.Clone()
 		newMP.Triangles[i] = newTri
 		newMP.sortedTriangles[i] = newTri
-		newMP.Vertices = tri.Vertices
+		newMP.Vertices = append(newMP.Vertices, tri.Vertices...)
 	}
 	newMP.Material = part.Material
 	return newMP


### PR DESCRIPTION
First of all, great project!

While testing your usage of [qmuntal/gltf](https://github.com/qmuntal/gltf) I noticed `LoadGLTFData` consumes quite a lot of memory compared to the size of the parsed glTF file. For example, `./example/logo/tetra3d.glb` weights ~58KB and `LoadGLTFData` consumes ~3MB and produces ~27k allocations!

My take is that most of the memory consumed by that function is accidental. A sane size to in-memory ratio would be 2 or 3x, not 58x.

This PR contains several memory improvements, which as side effect also have some net speed gains:

```txt
C:\Users\qmuntaldiaz\code\Tetra3d>benchstat old.txt new.txt
name             old time/op    new time/op    delta
LoadGLTFData-12    1.97ms ±10%    1.36ms ±15%  -30.67%  (p=0.000 n=9+9)

name             old speed      new speed      delta
LoadGLTFData-12  29.9MB/s ± 9%  43.1MB/s ±13%  +44.27%  (p=0.000 n=9+9)

name             old B/op       new B/op       delta
LoadGLTFData-12    3.17MB ± 0%    1.64MB ± 0%  -48.19%  (p=0.000 n=10+10)

name             old allocs/op  new allocs/op  delta
LoadGLTFData-12     27.6k ± 0%     25.5k ± 0%   -7.60%  (p=0.000 n=10+9)
```

