### PR TITLE
GLTF Export & Resolve Scene Resolution

### DIFF
--- a/gltf.go
+++ b/gltf.go
@@ -20,6 +20,7 @@ import (
 )
 
 type GLTFLoadOptions struct {
+	ResolveCameraRes          bool
 	CameraWidth, CameraHeight int  // Width and height of loaded Cameras. Defaults to 1920x1080.
 	CameraDepth               bool // If cameras should render depth or not
 	DefaultToAutoTransparency bool // If DefaultToAutoTransparency is true, then opaque materials become Auto transparent materials in Tetra3D.
@@ -37,6 +38,7 @@ type GLTFLoadOptions struct {
 // DefaultGLTFLoadOptions creates an instance of GLTFLoadOptions with some sensible defaults.
 func DefaultGLTFLoadOptions() *GLTFLoadOptions {
 	return &GLTFLoadOptions{
+		ResolveCameraRes:          true,
 		CameraWidth:               1920,
 		CameraHeight:              1080,
 		CameraDepth:               true,
@@ -101,6 +103,18 @@ func LoadGLTFData(data []byte, gltfLoadOptions *GLTFLoadOptions) (*Library, erro
 		if doc.Scenes[0].Extras != nil {
 
 			globalExporterSettings := doc.Scenes[0].Extras.(map[string]interface{})
+
+			if gltfLoadOptions.ResolveCameraRes {
+				if cr, exists := globalExporterSettings["t3dCameraResolution__"]; exists {
+					res := cr.([]interface{})
+					if w, ok := res[0].(float64); ok {
+						(*gltfLoadOptions).CameraWidth = int(w)
+					}
+					if h, ok := res[1].(float64); ok {
+						(*gltfLoadOptions).CameraHeight = int(h)
+					}
+				}
+			}
 
 			if et, exists := globalExporterSettings["t3dPackTextures__"]; exists {
 				t3dExport = true

--- a/tetra3d.py
+++ b/tetra3d.py
@@ -449,6 +449,9 @@ def export():
     
     globalSet("t3dCollections__", collections)
 
+    # set global camera resolution
+    globalSet("t3dCameraResolution__", [bpy.context.scene.render.resolution_x, bpy.context.scene.render.resolution_y])
+
     worlds = {}
 
     for world in bpy.data.worlds:


### PR DESCRIPTION
- Export Scene Resolution from Blender. (Scene>Format>Resolution)
- Resolve exported resolution in Tetra as Camera Width and Height.