### PR TITLE
fix: bounds check for gltf indices

### DIFF
--- a/gltf.go
+++ b/gltf.go
@@ -3,6 +3,7 @@ package tetra3d
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"image"
 	"io"
 	"io/fs"
@@ -676,6 +677,9 @@ func LoadGLTFData(data io.Reader, gltfLoadOptions *GLTFLoadOptions) (*Library, e
 			newIndices := make([]int, len(indices))
 
 			for i, j := range indices {
+				if int(j) >= len(vertexData) {
+					return nil, fmt.Errorf("invalid gltf: index %d out of bounds for vertex data length %d", j, len(vertexData))
+				}
 				newIndices[i] = int(j)
 			}
 


### PR DESCRIPTION
Closes #19

Added a bounds check for indices read from GLTF files. Previously, if a GLTF file contained primitive indices pointing outside the bound of the vertex attributes array (for example, if interleaved data generated by qmuntal/gltf was improperly exported as described in #19), it would panic with `index out of range`. 

Now, it properly returns an error `invalid gltf: index <x> out of bounds for vertex data length <y>` instead of panicking.